### PR TITLE
Fix WebDAV metadata checks for HTTP vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix local HTTP WebDAV vaults getting stuck on the initial metadata check before KeeForge could download and cache them.
 - macOS: system-wide AutoFill — passwords and passkeys in Safari, Chromium browsers, and native apps.
 - macOS: screen-privacy protections (blur on focus loss, optional screen-capture blocking), attachment Quick Look, and App Store review prompts.
 - macOS: native menu bar commands, Settings window, and automatic locking on screen lock/sleep; password reveal now always requires device-owner authentication (also hardened on iOS).

--- a/KeeForge/Services/Cloud/README.md
+++ b/KeeForge/Services/Cloud/README.md
@@ -15,7 +15,7 @@ This folder owns provider abstractions plus the cloud-backed open/save pipeline.
 - `WebDAVModels.swift` holds the WebDAV config/credential value types, HTTPS-by-default URL normalization with explicit HTTP opt-in, accountId derivation, and the `WebDAVConnecting` connect seam.
 - `WebDAVPropfindParser.swift` is a pure `XMLParser`-based multistatus parser (DAV: namespace only) that yields `[WebDAVResource]`.
 - `WebDAVClient.swift` is a `Sendable` transport (injectable closure; live ephemeral `URLSession` with same-origin redirect handling and preemptive Basic auth) plus the HTTP/URLError→`CloudProviderError` mapping.
-- `WebDAVCloudProvider.swift` implements `CloudProvider` + `WebDAVConnecting` for WebDAV: stateless, credential-per-call from `CloudTokenStore`, ETag-based `rev`, and folder/.kdbx listing. Wired via `provider(for:)` but intentionally left out of `availableProviders` until the UI slice ships.
+- `WebDAVCloudProvider.swift` implements `CloudProvider` + `WebDAVConnecting` for WebDAV: stateless, credential-per-call from `CloudTokenStore`, ETag-based `rev`, depth-zero `PROPFIND` metadata checks, and folder/.kdbx listing. Wired via `provider(for:)` but intentionally left out of `availableProviders` until the UI slice ships.
 
 ## Change Carefully
 

--- a/KeeForge/Services/Cloud/WebDAVCloudProvider.swift
+++ b/KeeForge/Services/Cloud/WebDAVCloudProvider.swift
@@ -123,36 +123,29 @@ final class WebDAVCloudProvider: CloudProvider, WebDAVConnecting, Sendable {
         let context = try resolveContext(accountId: accountId)
         let fileURL = Self.url(forFileId: fileId, base: context.baseURL)
 
-        let headResponse = try await client.head(url: fileURL, credential: context.credential)
-
-        // Some servers reject HEAD on WebDAV resources (405) — fall back to a
-        // PROPFIND Depth 0 for the same resource.
-        if headResponse.statusCode == 405 {
-            let probe = try await client.probe(url: fileURL, credential: context.credential)
-            if let error = WebDAVClient.mapHTTPStatus(probe.statusCode, isPropfind: true, responseBody: probe.data) {
-                throw error
-            }
-            let resources = try WebDAVPropfindParser.parse(data: probe.data, requestURL: fileURL, includeSelf: true)
-            guard let resource = resources.first else {
-                throw CloudProviderError.fileNotFound
-            }
-            return CloudFileMetadata(
-                modifiedDate: resource.lastModified ?? .now,
-                contentHash: nil,
-                size: resource.contentLength ?? 0,
-                rev: Self.rev(eTag: resource.eTag, lastModified: nil)
-            )
-        }
-
-        if let error = WebDAVClient.mapHTTPStatus(headResponse.statusCode, responseBody: headResponse.data) {
+        // Use the WebDAV-native metadata operation directly. A number of small
+        // local HTTP WebDAV servers accept PROPFIND but leave HEAD requests
+        // unanswered; on a first open that prevented KeeForge from ever
+        // reaching the GET that creates the shared cached copy.
+        let probe = try await client.probe(url: fileURL, credential: context.credential)
+        if let error = WebDAVClient.mapHTTPStatus(probe.statusCode, isPropfind: true, responseBody: probe.data) {
             throw error
         }
 
+        let resources = try WebDAVPropfindParser.parse(
+            data: probe.data,
+            requestURL: fileURL,
+            includeSelf: true
+        )
+        guard let resource = resources.first else {
+            throw CloudProviderError.fileNotFound
+        }
+
         return CloudFileMetadata(
-            modifiedDate: Self.date(fromLastModified: headResponse.lastModified) ?? .now,
+            modifiedDate: resource.lastModified ?? .now,
             contentHash: nil,
-            size: headResponse.contentLength ?? 0,
-            rev: Self.rev(from: headResponse)
+            size: resource.contentLength ?? 0,
+            rev: Self.rev(eTag: resource.eTag, lastModified: nil)
         )
     }
 

--- a/KeeForgeTests/WebDAVCloudProviderTests.swift
+++ b/KeeForgeTests/WebDAVCloudProviderTests.swift
@@ -168,15 +168,29 @@ final class WebDAVCloudProviderTests: XCTestCase {
 
     // MARK: - Provider: getMetadata
 
-    func testGetMetadataHappyPathViaHead() async throws {
+    func testGetMetadataUsesDepthZeroPropfind() async throws {
         let accountId = try seedCredential(username: "alice")
+        let multistatus = """
+        <?xml version="1.0"?>
+        <d:multistatus xmlns:d="DAV:">
+          <d:response>
+            <d:href>/dav/vault.kdbx</d:href>
+            <d:propstat>
+              <d:prop>
+                <d:resourcetype/>
+                <d:getcontentlength>2048</d:getcontentlength>
+                <d:getetag>"meta-etag"</d:getetag>
+                <d:getlastmodified>Tue, 01 Jul 2025 10:20:30 GMT</d:getlastmodified>
+              </d:prop>
+              <d:status>HTTP/1.1 200 OK</d:status>
+            </d:propstat>
+          </d:response>
+        </d:multistatus>
+        """
         let responder = TransportResponder { request in
-            XCTAssertEqual(request.httpMethod, "HEAD")
-            return StubResponse(status: 200, headers: [
-                "ETag": "\"meta-etag\"",
-                "Content-Length": "2048",
-                "Last-Modified": "Tue, 01 Jul 2025 10:20:30 GMT",
-            ])
+            XCTAssertEqual(request.httpMethod, "PROPFIND")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Depth"), "0")
+            return StubResponse(status: 207, headers: [:], body: Data(multistatus.utf8))
         }
         let provider = WebDAVCloudProvider(client: WebDAVClient(transport: responder.transport))
 
@@ -187,40 +201,24 @@ final class WebDAVCloudProviderTests: XCTestCase {
         XCTAssertEqual(metadata.size, 2048)
     }
 
-    func testGetMetadataHead405FallsBackToPropfind() async throws {
+    func testGetMetadataRejectsEmptyPropfindResponse() async throws {
         let accountId = try seedCredential(username: "alice")
         let multistatus = """
         <?xml version="1.0"?>
-        <d:multistatus xmlns:d="DAV:">
-          <d:response>
-            <d:href>/dav/vault.kdbx</d:href>
-            <d:propstat>
-              <d:prop>
-                <d:resourcetype/>
-                <d:getcontentlength>777</d:getcontentlength>
-                <d:getetag>"probe-etag"</d:getetag>
-                <d:getlastmodified>Fri, 04 Jul 2025 09:00:00 GMT</d:getlastmodified>
-              </d:prop>
-              <d:status>HTTP/1.1 200 OK</d:status>
-            </d:propstat>
-          </d:response>
-        </d:multistatus>
+        <d:multistatus xmlns:d="DAV:"/>
         """
         let responder = TransportResponder { request in
-            if request.httpMethod == "HEAD" {
-                return StubResponse(status: 405, headers: [:])
-            }
             XCTAssertEqual(request.httpMethod, "PROPFIND")
-            XCTAssertEqual(request.value(forHTTPHeaderField: "Depth"), "0")
             return StubResponse(status: 207, headers: [:], body: Data(multistatus.utf8))
         }
         let provider = WebDAVCloudProvider(client: WebDAVClient(transport: responder.transport))
 
-        let metadata = try await provider.getMetadata(accountId: accountId, fileId: "/vault.kdbx")
-
-        XCTAssertEqual(metadata.rev, "\"probe-etag\"")
-        XCTAssertEqual(metadata.size, 777)
-        XCTAssertNil(metadata.contentHash)
+        do {
+            _ = try await provider.getMetadata(accountId: accountId, fileId: "/vault.kdbx")
+            XCTFail("Expected file-not-found for an empty metadata response")
+        } catch let error as CloudProviderError {
+            XCTAssertEqual(error, .fileNotFound)
+        }
     }
 
     // MARK: - Provider: upload


### PR DESCRIPTION
## Summary

- use a depth-zero WebDAV `PROPFIND` for file metadata checks
- avoid relying on `HEAD` before the initial database download
- cover successful and empty metadata responses with focused provider tests

## Root cause

Some lightweight local HTTP WebDAV servers support WebDAV `PROPFIND` but leave `HEAD` requests unanswered. KeeForge performed `HEAD` before `GET`, so the first open could remain stuck on “Syncing with WebDAV…” and never create the shared cached copy.

## Impact

Local HTTP WebDAV vaults can complete their initial metadata check, download, and cache normally.

## Validation

- `xcodebuild test -project KeeForge.xcodeproj -scheme KeeForge -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /tmp/KeeForgeIssue12Derived -only-testing:KeeForgeTests/WebDAVCloudProviderTests -quiet`

Closes #12
