### PR TITLE
Update GitHub links to the KeeForge org after repo transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update GitHub links (Report a Bug, Source Code, docs) to the new KeeForge org after the repository transfer.
 - Fix local HTTP WebDAV vaults getting stuck on the initial metadata check before KeeForge could download and cache them.
 - Password reveal and copy now always require device-owner authentication, even when biometrics are unavailable (hardening back-ported from the macOS work).
 - Internal: restructure the AutoFill extension for upcoming macOS support (no user-facing change).

--- a/KeeForge/Views/SettingsView.swift
+++ b/KeeForge/Views/SettingsView.swift
@@ -506,11 +506,11 @@ private struct AboutSectionContent: View {
                 Label("Contact Support", systemImage: "envelope")
             }
 
-            Link(destination: URL(string: "https://github.com/crazytan/KeeForge/issues")!) {
+            Link(destination: URL(string: "https://github.com/KeeForge/KeeForge/issues")!) {
                 Label("Report a Bug", systemImage: "ladybug")
             }
 
-            Link(destination: URL(string: "https://github.com/crazytan/KeeForge")!) {
+            Link(destination: URL(string: "https://github.com/KeeForge/KeeForge")!) {
                 Label("Source Code", systemImage: "chevron.left.forwardslash.chevron.right")
             }
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://apps.apple.com/us/app/keeforge/id6759309295">
     <img alt="Download on the App Store" src="https://img.shields.io/badge/App%20Store-Download-0D96F6?style=for-the-badge&logo=appstore&logoColor=white" />
   </a>
-  <img alt="Swift LoC" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Ftokei.kojix2.net%2Fapi%2Fgithub%2Fcrazytan%2FKeeForge%2Flanguages&query=%24.data.languages.Swift.code&label=swift%20loc&color=orange&style=for-the-badge" />
+  <img alt="Swift LoC" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Ftokei.kojix2.net%2Fapi%2Fgithub%2FKeeForge%2FKeeForge%2Flanguages&query=%24.data.languages.Swift.code&label=swift%20loc&color=orange&style=for-the-badge" />
   <a href="LICENSE">
     <img alt="License: GPLv3" src="https://img.shields.io/badge/license-GPLv3-blue?style=for-the-badge" />
   </a>
@@ -101,7 +101,7 @@ TestFixtures/         # Sample .kdbx databases and key files
 
 - App Store: [KeeForge on the App Store](https://apps.apple.com/us/app/keeforge/id6759309295)
 - Email: [support@keeforge.com](mailto:support@keeforge.com)
-- Issues: [GitHub Issues](https://github.com/crazytan/KeeForge/issues)
+- Issues: [GitHub Issues](https://github.com/KeeForge/KeeForge/issues)
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,9 @@ A free, open-source KeePass password manager for iOS.
 Having issues or have a question? Reach out:
 
 - **Email:** tjtanjia.tan@gmail.com
-- **GitHub Issues:** [github.com/crazytan/KeeForge/issues](https://github.com/crazytan/KeeForge/issues)
+- **GitHub Issues:** [github.com/KeeForge/KeeForge/issues](https://github.com/KeeForge/KeeForge/issues)
 
 ## Links
 
 - [Privacy Policy](https://keeforge.com/privacy)
-- [Source Code](https://github.com/crazytan/KeeForge)
+- [Source Code](https://github.com/KeeForge/KeeForge)


### PR DESCRIPTION
Points the About screen (Report a Bug, Source Code), README badge/links, and docs support page at github.com/KeeForge/KeeForge after the repository transfer. Adds a CHANGELOG entry under Unreleased.