### PR TITLE
Treat local database files in Recently Deleted as unavailable

### DIFF
--- a/AutoFillExtension/Localizable.xcstrings
+++ b/AutoFillExtension/Localizable.xcstrings
@@ -12,6 +12,16 @@
         }
       }
     },
+    "The database file is in Recently Deleted in the Files app. Restore it in Files, or remove this database and add the current file again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Datenbankdatei befindet sich in „Zuletzt gelöscht“ in der Dateien-App. Stellen Sie sie in der Dateien-App wieder her, oder entfernen Sie diese Datenbank und fügen Sie die aktuelle Datei erneut hinzu."
+          }
+        }
+      }
+    },
     "“%@” is already in your database list.": {
       "localizations": {
         "de": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix local databases silently opening a stale copy after the file was deleted or replaced in the Files app (#13): iOS bookmarks follow the old file into Recently Deleted, so KeeForge now detects a trashed database file, refuses to open or save to it, and explains how to restore or re-add the current file.
+
 - Add full German localization (iOS app, macOS app, and AutoFill extension): 648 strings across UI, error messages, alerts, and Info.plist usage descriptions, plus a localization test suite that gates translation completeness, format-specifier parity, and app/extension consistency.
 - Show TOTP codes for entries created by the KeeOTP/KeeOtp2 plugins (`key=...` values in the otp/OTP/Otp fields, with Base32, Base64, Hex, and UTF8 secret encodings, and KeeOtp2's defaults for omitted parameters), preserving the original field spelling and query verbatim when editing and saving.
 - Update GitHub links (Report a Bug, Source Code, docs) to the new KeeForge org after the repository transfer.

--- a/KeeForge/Resources/Localizable.xcstrings
+++ b/KeeForge/Resources/Localizable.xcstrings
@@ -44,6 +44,36 @@
         }
       }
     },
+    "Database Is in Recently Deleted": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datenbank befindet sich in „Zuletzt gelöscht“"
+          }
+        }
+      }
+    },
+    "The database file is in Recently Deleted in the Files app. Restore it in Files, or remove this database and add the current file again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Datenbankdatei befindet sich in „Zuletzt gelöscht“ in der Dateien-App. Stellen Sie sie in der Dateien-App wieder her, oder entfernen Sie diese Datenbank und fügen Sie die aktuelle Datei erneut hinzu."
+          }
+        }
+      }
+    },
+    "The database file was moved to Recently Deleted in the Files app — it may have been deleted, or replaced by a newer copy. Restore it in Files, or remove this database in KeeForge and add the current file again.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Datenbankdatei wurde in der Dateien-App nach „Zuletzt gelöscht“ verschoben – sie wurde möglicherweise gelöscht oder durch eine neuere Kopie ersetzt. Stellen Sie sie in der Dateien-App wieder her, oder entfernen Sie diese Datenbank in KeeForge und fügen Sie die aktuelle Datei erneut hinzu."
+          }
+        }
+      }
+    },
     "“%@” is already in your database list.": {
       "localizations": {
         "de": {

--- a/KeeForge/Services/Persistence/DatabaseListStore.swift
+++ b/KeeForge/Services/Persistence/DatabaseListStore.swift
@@ -362,12 +362,59 @@ enum DatabaseListStore {
         return cacheURL(for: reference.id)
     }
 
-    static func resolveDatabaseURL(for reference: DatabaseReference) -> URL? {
-        resolveURL(from: reference.bookmarkData) { refreshedBookmarkData in
+    enum LocalDatabaseFileLocation: Equatable, Sendable {
+        case available(URL)
+        case inTrash(URL)
+    }
+
+    enum LocalDatabaseFileError: Error, LocalizedError, Equatable, Sendable {
+        case databaseInTrash
+
+        var errorDescription: String? {
+            String(localized: "The database file is in Recently Deleted in the Files app. Restore it in Files, or remove this database and add the current file again.")
+        }
+    }
+
+    /// Resolves a local database's bookmark and classifies the result. iOS
+    /// bookmarks follow file identity, so after a Files-app Delete or Replace
+    /// the bookmark still resolves — to the old copy sitting in Recently
+    /// Deleted. That copy must never be read, written, cached, or re-minted
+    /// into a fresh bookmark: restoring the file in Files keeps the original
+    /// bookmark valid, and once the trashed copy is purged, resolution falls
+    /// back to the stored path and rebinds to whatever file now lives there.
+    static func locateDatabaseFile(for reference: DatabaseReference) -> LocalDatabaseFileLocation? {
+        guard let bookmarkData = reference.bookmarkData,
+              let resolved = SecurityScopedBookmarkManager.resolveURL(from: bookmarkData) else {
+            return nil
+        }
+
+        let url = resolved.url
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessed {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        if SecurityScopedBookmarkManager.isInTrashDirectory(url) {
+            return .inTrash(url)
+        }
+
+        if resolved.isStale,
+           let refreshedBookmarkData = try? SecurityScopedBookmarkManager.makeBookmarkData(for: url) {
             var refreshedReference = reference
             refreshedReference.bookmarkData = refreshedBookmarkData
             update(refreshedReference)
         }
+
+        return .available(url)
+    }
+
+    static func resolveDatabaseURL(for reference: DatabaseReference) -> URL? {
+        guard case .available(let url) = locateDatabaseFile(for: reference) else {
+            return nil
+        }
+        return url
     }
 
     static func resolveKeyFileURL(for reference: DatabaseReference) -> URL? {

--- a/KeeForge/Services/Persistence/README.md
+++ b/KeeForge/Services/Persistence/README.md
@@ -8,7 +8,7 @@ This folder owns database references, cached copies, file access, and local-save
 - `DatabaseCreationService.swift` prepares new KDBX databases and registers local or cloud-created references after the durable copy is available.
 - `LocalDatabaseSaver.swift` handles atomic local saves, open-time conflict detection, backup rotation, and shared-cache refresh.
 - `SharedVaultStore.swift` reads and writes the shared cached database copy used by the app and AutoFill extension.
-- `SecurityScopedBookmarkManager.swift` and `CoordinatedFileReader.swift` handle bookmark resolution and coordinated file access.
+- `SecurityScopedBookmarkManager.swift` and `CoordinatedFileReader.swift` handle bookmark resolution and coordinated file access. Bookmarks track file identity, so a Files-app Delete or Replace leaves them resolving to the old copy in Recently Deleted; `DatabaseListStore.locateDatabaseFile(for:)` classifies that as `.inTrash` and every database read/save path treats it as unavailable instead of silently using the stale copy.
 - `DocumentPickerService.swift`, `KeyFileProcessor.swift`, and `SyncedFolderDetector.swift` cover file picking, key-file parsing, and synced-folder classification.
 
 ## Change Carefully

--- a/KeeForge/Services/Persistence/SecurityScopedBookmarkManager.swift
+++ b/KeeForge/Services/Persistence/SecurityScopedBookmarkManager.swift
@@ -28,6 +28,30 @@ enum SecurityScopedBookmarkManager {
         )
     }
 
+    /// Whether `url` points inside a trash directory ("Recently Deleted" in the
+    /// Files app). Bookmarks track file identity, so Files operations like
+    /// Delete or Replace leave a resolvable bookmark aimed at the old copy in
+    /// `.Trash`; callers that read or write databases must treat that copy as
+    /// unavailable. `getRelationship` is authoritative where it works, but it
+    /// misses some file-provider trash domains, so an exact `.Trash` path
+    /// component is also honored. For the relationship check to see files
+    /// outside the sandbox, call this while security-scoped access to `url`
+    /// is active.
+    static func isInTrashDirectory(_ url: URL) -> Bool {
+        var relationship = FileManager.URLRelationship.other
+        if (try? FileManager.default.getRelationship(
+            &relationship,
+            of: .trashDirectory,
+            in: [],
+            toItemAt: url
+        )) != nil,
+            relationship == .contains {
+            return true
+        }
+
+        return url.pathComponents.contains(".Trash")
+    }
+
     static func resolveURL(from bookmarkData: Data) -> (url: URL, isStale: Bool)? {
         var isStale = false
         if let url = try? URL(

--- a/KeeForge/ViewModels/DatabaseOpenFailure.swift
+++ b/KeeForge/ViewModels/DatabaseOpenFailure.swift
@@ -287,6 +287,19 @@ struct DatabaseOpenFailure: Equatable, Sendable {
         isCloudBacked: Bool,
         diagnostics: DatabaseOpenDiagnostics? = nil
     ) -> DatabaseOpenFailure {
+        if case DatabaseListStore.LocalDatabaseFileError.databaseInTrash = error {
+            return DatabaseOpenFailure(
+                title: String(localized: "Database Is in Recently Deleted"),
+                summary: String(localized: "The database file was moved to Recently Deleted in the Files app — it may have been deleted, or replaced by a newer copy. Restore it in Files, or remove this database in KeeForge and add the current file again."),
+                technicalDetails: technicalDetails(for: error),
+                errorCode: "file.in_recently_deleted",
+                category: .fileAccess,
+                countsTowardFailedAttempts: false,
+                canChooseDifferentFile: true,
+                diagnostics: diagnostics
+            )
+        }
+
         if error is CoordinatedFileReader.TimeoutError {
             return DatabaseOpenFailure(
                 title: String(localized: "Database Server Unavailable"),

--- a/KeeForge/ViewModels/DatabaseViewModel.swift
+++ b/KeeForge/ViewModels/DatabaseViewModel.swift
@@ -1576,8 +1576,11 @@ final class DatabaseViewModel {
         reference: DatabaseReference
     ) async throws -> LocalDatabaseReadResult {
         try await CoordinatedFileReader.performBlocking(timeout: localDatabaseReadTimeout) {
-            guard let url = DatabaseListStore.resolveDatabaseURL(for: reference) else {
+            guard let location = DatabaseListStore.locateDatabaseFile(for: reference) else {
                 throw CocoaError(.fileReadNoSuchFile)
+            }
+            guard case .available(let url) = location else {
+                throw DatabaseListStore.LocalDatabaseFileError.databaseInTrash
             }
 
             let hasSecurityScope = url.startAccessingSecurityScopedResource()
@@ -1674,8 +1677,27 @@ final class DatabaseViewModel {
         bytes: Data
     ) async throws {
         try await Task.detached(priority: .utility) {
-            let originalURL = DatabaseListStore.resolveDatabaseURL(for: reference) ?? DatabaseListStore.cacheLocation(for: reference)
-            let usesSecurityScope = reference.bookmarkData != nil
+            let originalURL: URL
+            let usesSecurityScope: Bool
+            if reference.bookmarkData == nil {
+                // App-only databases live in the shared cache; the conflict
+                // copy lands next to it, where the database itself is read.
+                originalURL = DatabaseListStore.cacheLocation(for: reference)
+                usesSecurityScope = false
+            } else {
+                // A bookmarked database must resolve to a usable file — the
+                // cache directory is not user-visible, so writing the copy
+                // there would silently strand it. Failing keeps the draft
+                // alive for the user to retry.
+                guard let location = DatabaseListStore.locateDatabaseFile(for: reference) else {
+                    throw SaveError.databaseLocationUnavailable
+                }
+                guard case .available(let url) = location else {
+                    throw DatabaseListStore.LocalDatabaseFileError.databaseInTrash
+                }
+                originalURL = url
+                usesSecurityScope = true
+            }
             let hasSecurityScope = usesSecurityScope ? originalURL.startAccessingSecurityScopedResource() : false
             defer {
                 if hasSecurityScope {
@@ -1734,8 +1756,11 @@ final class DatabaseViewModel {
             data = resolution.data
             updatedReference = resolution.reference
         } else {
-            guard let url = DatabaseListStore.resolveDatabaseURL(for: reference) else {
+            guard let location = DatabaseListStore.locateDatabaseFile(for: reference) else {
                 throw SaveError.databaseLocationUnavailable
+            }
+            guard case .available(let url) = location else {
+                throw DatabaseListStore.LocalDatabaseFileError.databaseInTrash
             }
             data = try readSecurityScopedData(from: url)
             updatedReference = reference

--- a/KeeForgeTests/DatabaseListStoreTests.swift
+++ b/KeeForgeTests/DatabaseListStoreTests.swift
@@ -232,6 +232,73 @@ final class DatabaseListStoreTests: XCTestCase {
         XCTAssertEqual(DatabaseListStore.activeAutoFillDatabaseID, first.id)
     }
 
+    func testLocateDatabaseFileReturnsAvailableForRegularFile() throws {
+        let url = try makeTemporaryFileURL(name: "regular.kdbx")
+        let reference = try DatabaseListStore.add(url: url)
+
+        let location = try XCTUnwrap(DatabaseListStore.locateDatabaseFile(for: reference))
+
+        guard case .available(let resolvedURL) = location else {
+            XCTFail("Expected .available, got \(location)")
+            return
+        }
+        XCTAssertEqual(resolvedURL.path, url.path)
+        XCTAssertEqual(DatabaseListStore.resolveDatabaseURL(for: reference)?.path, url.path)
+    }
+
+    func testLocateDatabaseFileReportsTrashedFile() throws {
+        let trashedURL = try makeTemporaryFileURL(name: ".Trash/personal.kdbx")
+        let reference = try TestDatabaseSupport.makeReference(for: trashedURL)
+
+        let location = try XCTUnwrap(DatabaseListStore.locateDatabaseFile(for: reference))
+
+        guard case .inTrash(let resolvedURL) = location else {
+            XCTFail("Expected .inTrash, got \(location)")
+            return
+        }
+        XCTAssertTrue(resolvedURL.pathComponents.contains(".Trash"))
+        XCTAssertNil(DatabaseListStore.resolveDatabaseURL(for: reference))
+    }
+
+    func testLocateDatabaseFileFollowsMoveIntoTrashAndDoesNotRefreshBookmark() throws {
+        // Mirrors deleting the database in the Files app: the bookmarked file
+        // keeps its identity and moves into ".Trash". Resolution follows the
+        // identity there; the result must be classified as trashed instead of
+        // silently serving the stale copy, and the (now stale) bookmark must
+        // not be re-minted against the trashed location — restoring the file
+        // in Files keeps the original bookmark valid.
+        //
+        // (The Files-app "Replace" flow — a new file taking over the original
+        // path — cannot be reproduced on a plain filesystem: without a file
+        // provider in the middle, resolution rebinds to the path. On device
+        // the bookmark keeps following the old provider item into the trash,
+        // which is this same classification path.)
+        let originalURL = try makeTemporaryFileURL(name: "deleted.kdbx", contents: Data("old contents".utf8))
+        let reference = try DatabaseListStore.add(url: originalURL)
+
+        let fileManager = FileManager.default
+        let trashDirectoryURL = originalURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".Trash", isDirectory: true)
+        try fileManager.createDirectory(at: trashDirectoryURL, withIntermediateDirectories: true)
+        try fileManager.moveItem(
+            at: originalURL,
+            to: trashDirectoryURL.appendingPathComponent("deleted.kdbx")
+        )
+
+        let location = try XCTUnwrap(DatabaseListStore.locateDatabaseFile(for: reference))
+
+        guard case .inTrash(let resolvedURL) = location else {
+            XCTFail("Expected .inTrash, got \(location)")
+            return
+        }
+        XCTAssertTrue(resolvedURL.pathComponents.contains(".Trash"))
+        XCTAssertNil(DatabaseListStore.resolveDatabaseURL(for: reference))
+
+        let storedReference = try XCTUnwrap(DatabaseListStore.databases.first(where: { $0.id == reference.id }))
+        XCTAssertEqual(storedReference.bookmarkData, reference.bookmarkData)
+    }
+
     private func makeTemporaryFileURL(name: String, contents: Data = Data("fixture".utf8)) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/KeeForgeTests/DatabaseViewModelTests.swift
+++ b/KeeForgeTests/DatabaseViewModelTests.swift
@@ -192,6 +192,30 @@ final class DatabaseViewModelTests: XCTestCase {
         XCTAssertFalse(vm.openFailure?.countsTowardFailedAttempts ?? true)
     }
 
+    func testUnlockFailsWhenDatabaseFileIsInRecentlyDeleted() async throws {
+        // A bookmark follows its file into the Files app's Recently Deleted
+        // (".Trash"), so unlock must refuse the stale copy with a dedicated
+        // failure instead of silently opening it.
+        let fileManager = FileManager.default
+        let trashDirectoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent(".Trash", isDirectory: true)
+        try fileManager.createDirectory(at: trashDirectoryURL, withIntermediateDirectories: true)
+        let trashedURL = trashDirectoryURL.appendingPathComponent("test.kdbx")
+        try fileManager.copyItem(at: fixtureURL(), to: trashedURL)
+        let reference = try TestDatabaseSupport.makeReference(for: trashedURL)
+        let vm = DatabaseViewModel(databaseReference: reference)
+
+        await vm.unlock(password: fixturePassword)
+
+        XCTAssertState(vm.state, is: .error)
+        XCTAssertEqual(vm.openFailure?.errorCode, "file.in_recently_deleted")
+        XCTAssertEqual(vm.openFailure?.category, .fileAccess)
+        XCTAssertFalse(vm.openFailure?.countsTowardFailedAttempts ?? true)
+        XCTAssertNil(vm.rootGroup)
+        XCTAssertNil(DatabaseListStore.cachedDatabaseURL(for: reference.id))
+    }
+
     func testBlockingFileAccessTimesOutWithoutBlockingCallerActor() async {
         do {
             let _: Data = try await CoordinatedFileReader.performBlocking(timeout: .milliseconds(20)) {

--- a/KeeForgeTests/SecurityScopedBookmarkManagerTests.swift
+++ b/KeeForgeTests/SecurityScopedBookmarkManagerTests.swift
@@ -64,6 +64,32 @@ final class SecurityScopedBookmarkManagerTests: XCTestCase {
     }
     #endif
 
+    func testIsInTrashDirectoryMatchesExactTrashPathComponent() throws {
+        let trashedURL = try makeTemporaryFileURL(name: ".Trash/trashed.kdbx")
+
+        XCTAssertTrue(SecurityScopedBookmarkManager.isInTrashDirectory(trashedURL))
+    }
+
+    func testIsInTrashDirectoryMatchesNestedTrashSubfolder() throws {
+        let trashedURL = try makeTemporaryFileURL(name: ".Trash/subfolder/trashed.kdbx")
+
+        XCTAssertTrue(SecurityScopedBookmarkManager.isInTrashDirectory(trashedURL))
+    }
+
+    func testIsInTrashDirectoryIgnoresSimilarlyNamedFolders() throws {
+        // Only the exact ".Trash" component counts; a user folder that merely
+        // starts with the same prefix must stay fully usable.
+        let lookalikeURL = try makeTemporaryFileURL(name: ".TrashCan/database.kdbx")
+
+        XCTAssertFalse(SecurityScopedBookmarkManager.isInTrashDirectory(lookalikeURL))
+    }
+
+    func testIsInTrashDirectoryIsFalseForRegularFiles() throws {
+        let url = try makeTemporaryFileURL(name: "regular.kdbx")
+
+        XCTAssertFalse(SecurityScopedBookmarkManager.isInTrashDirectory(url))
+    }
+
     private func makeTemporaryFileURL(name: String) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
Fixes the silent-stale-open behavior behind #13.

## Root cause

iOS security-scoped bookmarks track **file identity**, not path. When a database is deleted in the Files app — or replaced via AirDrop + "Replace", which moves the old copy aside — the bookmark keeps resolving to the old file inside `.Trash` (Recently Deleted), and KeeForge silently opened that stale copy. Apple DTS confirms this exact scenario (developer.apple.com/forums/thread/813329): Files "Replace" behaves as delete-old-to-trash + move-new-into-place, and there is no public API to force path-based resolution or to silently rebind to the new file at the old path.

## Fix (KeePassium-parity trash detection)

- `DatabaseListStore.locateDatabaseFile(for:)` classifies every bookmark resolution as `.available` / `.inTrash` / unresolvable, using `FileManager.getRelationship(.trashDirectory)` with an exact `.Trash` path-component fallback — the heuristic DTS endorses and KeePassium ships.
- Trashed locations are never read, cached, saved to, used as conflict-copy targets, or re-minted into fresh bookmarks (re-minting would permanently pin the reference to the trash).
- Unlock surfaces a dedicated failure — **"Database Is in Recently Deleted"** (`file.in_recently_deleted`) — telling the user to restore the file in Files or re-add the current one, instead of silently opening stale data.
- Recovery is self-healing: restoring the file in Files keeps the original bookmark valid, and once the trashed copy is purged (30 days), resolution falls back to the stored path and rebinds to the replacement file automatically.
- German translations included; localization gate passes.

## Intentionally unchanged

- AutoFill keeps its cache-first read (serving the last-known copy offline is the same trade as cloud offline mode; resolving bookmarks in the extension hot path risks file-provider hangs the repo previously fixed).
- Key-file bookmarks still follow identity (a trashed key file is far rarer, and its bytes remain correct).

## Tests

New coverage: trash detection heuristics, `.inTrash` classification (including a real move-into-`.Trash` identity-follow test), no-re-mint-into-trash, and the unlock failure path. Ran `SecurityScopedBookmarkManagerTests`, `DatabaseListStoreTests`, `DatabaseViewModelTests`, `LocalDatabaseSaverTests`, `LocalizationTests` on iPhone 17 Pro sim — all pass except three pre-existing cloud-banner tests that hardcode English literals and fail on a German-language simulator (unrelated; tracked separately). `KeeForgeMac` builds clean.